### PR TITLE
Add transform tolerance to the nvblox costmap layer plugin

### DIFF
--- a/nvblox_nav2/include/nvblox_nav2/nvblox_costmap_layer.hpp
+++ b/nvblox_nav2/include/nvblox_nav2/nvblox_costmap_layer.hpp
@@ -62,6 +62,7 @@ private:
   bool convert_to_binary_costmap_ = false;
   float max_obstacle_distance_ = 1.0f;
   float inflation_distance_ = 0.5f;
+  double transform_tolerance_ = .0f;
   // This should not include any "special" values like 255.
   uint8_t max_cost_value_ = 252;
 

--- a/nvblox_nav2/src/nvblox_costmap_layer.cpp
+++ b/nvblox_nav2/src/nvblox_costmap_layer.cpp
@@ -54,6 +54,8 @@ void NvbloxCostmapLayer::onInitialize()
     node->declare_parameter<float>(getFullName("inflation_distance"), inflation_distance_);
   max_cost_value_ =
     node->declare_parameter<uint8_t>(getFullName("max_cost_value"), max_cost_value_);
+  transform_tolerance_ =
+      node->declare_parameter<double>(getFullName("transform_tolerance"), transform_tolerance_);
 
   RCLCPP_INFO_STREAM(
     node->get_logger(),
@@ -247,7 +249,7 @@ void NvbloxCostmapLayer::sliceCallback(
     // Get the transform from tf.
     try {
       T_G_S_msg =
-        tf_buffer_->lookupTransform(nav2_costmap_global_frame_, slice_frame, timestamp).transform;
+        tf_buffer_->lookupTransform(nav2_costmap_global_frame_, slice_frame, timestamp,  tf2::durationFromSec(transform_tolerance_)).transform;
     } catch (tf2::TransformException & e) {
       RCLCPP_WARN_STREAM_THROTTLE(
         node->get_logger(), clk, kWarnMessagePeriodMs,


### PR DESCRIPTION
* [nvblox_costmap_layer] add transform tolerance to lookup transform call

* [nvblox_costmap_layer] change default of transform_tolerance to 0.3 seconds

* [nvblox_costmap_layer] set transform tolerance to 0 for backward compatibility

---------


(cherry picked from commit 50817168b671386250710527d16518a9f8629fb1)